### PR TITLE
FIX: Do not import solution from practice

### DIFF
--- a/exercises/async-activity-completion/practice/starter/main.go
+++ b/exercises/async-activity-completion/practice/starter/main.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"log"
 
-	async "interacting/exercises/async-activity-completion/solution"
+	async "interacting/exercises/async-activity-completion/practice"
 
 	"go.temporal.io/sdk/client"
 )

--- a/exercises/async-activity-completion/practice/worker/main.go
+++ b/exercises/async-activity-completion/practice/worker/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"log"
 
-	async "interacting/exercises/async-activity-completion/solution"
+	async "interacting/exercises/async-activity-completion/practice"
 
 	"go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/worker"

--- a/exercises/querying-workflows/practice/signalclient/main.go
+++ b/exercises/querying-workflows/practice/signalclient/main.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"log"
 
-	queries "interacting/exercises/querying-workflows/solution"
+	queries "interacting/exercises/querying-workflows/practice"
 
 	"go.temporal.io/sdk/client"
 )

--- a/exercises/querying-workflows/practice/starter/main.go
+++ b/exercises/querying-workflows/practice/starter/main.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"log"
 
-	queries "interacting/exercises/querying-workflows/solution"
+	queries "interacting/exercises/querying-workflows/practice"
 
 	"go.temporal.io/sdk/client"
 )

--- a/exercises/querying-workflows/practice/worker/main.go
+++ b/exercises/querying-workflows/practice/worker/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"log"
 
-	queries "interacting/exercises/querying-workflows/solution"
+	queries "interacting/exercises/querying-workflows/practice"
 
 	"go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/worker"

--- a/exercises/sending-signals-external/practice/start/main.go
+++ b/exercises/sending-signals-external/practice/start/main.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	pizza "interacting/exercises/sending-signals-external/solution"
+	pizza "interacting/exercises/sending-signals-external/practice"
 	"log"
 
 	"go.temporal.io/sdk/client"

--- a/exercises/sending-signals-external/practice/worker/main.go
+++ b/exercises/sending-signals-external/practice/worker/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"log"
 
-	pizza "interacting/exercises/sending-signals-external/solution"
+	pizza "interacting/exercises/sending-signals-external/practice"
 
 	"go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/worker"


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
I've replaced references to `solution` in files under `practice/` folders.


## Why?
<!-- Tell your future self why have you made these changes -->
If the worker registers the workflows/activities from `solution` then:
- it doesn't matter what code we write in the `practice` packages
- we can't experiment because e.g. the worker will still run the code from `solution` so we can't check what Temporal does if we deviate from the instructions

## Checklist
<!--- add/delete as needed --->

1. How was this tested: I was able to complete all 4 exercises after making this change.
<!--- Please describe how you tested your changes/how we can test them -->

2. Any docs updates needed?: I don't think so.
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

## Notes
I haven't checked any other go edu repositories for this issue but if you agree with this change then I think checking them would be worthwhile.
