### PR TITLE
fix: avoid solution imports within practice

### DIFF
--- a/exercises/async-activity-completion/practice/starter/main.go
+++ b/exercises/async-activity-completion/practice/starter/main.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"log"
 
-	async "interacting/exercises/async-activity-completion/solution"
+	async "interacting/exercises/async-activity-completion/practice"
 
 	"go.temporal.io/sdk/client"
 )

--- a/exercises/async-activity-completion/practice/worker/main.go
+++ b/exercises/async-activity-completion/practice/worker/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"log"
 
-	async "interacting/exercises/async-activity-completion/solution"
+	async "interacting/exercises/async-activity-completion/practice"
 
 	"go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/worker"

--- a/exercises/querying-workflows/practice/signalclient/main.go
+++ b/exercises/querying-workflows/practice/signalclient/main.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"log"
 
-	queries "interacting/exercises/querying-workflows/solution"
+	queries "interacting/exercises/querying-workflows/practice"
 
 	"go.temporal.io/sdk/client"
 )

--- a/exercises/querying-workflows/practice/starter/main.go
+++ b/exercises/querying-workflows/practice/starter/main.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"log"
 
-	queries "interacting/exercises/querying-workflows/solution"
+	queries "interacting/exercises/querying-workflows/practice"
 
 	"go.temporal.io/sdk/client"
 )

--- a/exercises/querying-workflows/practice/worker/main.go
+++ b/exercises/querying-workflows/practice/worker/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"log"
 
-	queries "interacting/exercises/querying-workflows/solution"
+	queries "interacting/exercises/querying-workflows/practice"
 
 	"go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/worker"


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
in 2 exercises, the practice code has solution imports
- `async-activity-completion`
- `querying-workflows`

## Why?
<!-- Tell your future self why have you made these changes -->
This looks like copy-pasta typos.
but more importantly while doing the exercise, I was wondering why my query handlers and workflow changes were not being reflected. it will avoid that experience for anyone taking this course


## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
not much to test. they are practice and have intentional fixes waiting for course takers

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
