### PR TITLE
VLN-459: Set explicit permissions for GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   build-and-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- `.github/workflows/ci.yml`: Added a workflow-level permissions block granting only read access to repository contents to align the CI job with least-privilege guidance.